### PR TITLE
Improve document formatting

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -1,3 +1,5 @@
+\pdfoutput=1
+
 \documentclass[10pt]{searchthesis}%,makeidx
 %%% For an A4 format, use there options instead
 %\documentclass[12pt,makeidx]{phdthesis}
@@ -39,12 +41,19 @@
 %%% Formatting
 \usepackage[round]{natbib}
 \usepackage[resetlabels]{multibib}
+% Better hyphenation for URLs. Need to be loaded before the `hyperref`.
+\usepackage[hyphens]{url}
 \usepackage{hyperref}
 \usepackage{cleveref}
-\usepackage{siunitx}
+% Honor the surrounding font in some version of `siunitx`.
+\usepackage[detect-all]{siunitx}
+% Format units using the US spelling that is used as a de facto standard.
+\sisetup{group-separator={,},group-minimum-digits={3},output-decimal-marker={.}}
 \usepackage{enumitem}
 \usepackage{listings}
 \usepackage{epigraph}
+% The ACM Publishing System (TAPS) accepted way to typeset quotations.
+\usepackage{dirtytalk}
 
 \usepackage[table,dvipsnames,svgnames,x11names]{xcolor}
 
@@ -101,19 +110,19 @@
 	\pagenumbering{roman}
 	\tableofcontents
 	\newpage
-	
+
 	%%% Acknowledgements
 	\cleardoublepage
 	\include{c0-acknowledgements}
 	\newpage
-	
+
 	%%% List of Figures
 	\cleardoublepage
 	\phantomsection
 	\addcontentsline{toc}{chapter}{List of Figures}
 	\listoffigures
 	\newpage
-	
+
 	%%% List of Tables
 	\cleardoublepage
 	\phantomsection


### PR DESCRIPTION
Changes contained in this commit:

- Explicitly produce PDFs. See https://www.overleaf.com/learn/latex/%5Cpdfoutput for context.

- Better detection of surrounding fonts for some versions of `siunitx` package. See https://github.com/josephwright/siunitx/blob/main/CHANGELOG.md#removed for details about the latest.

- Use US spelling in formatting the numbers.

- Pass `hyphens` option to `url` package. This helps with the long URLs in the biography.

- Use the `dirtytalk` package for quotations. Utilize as `\say{This is a quote}`.

@feitosa-daniel: I am not sure who is supposed to approve or review these changes ;-) Tagging you because the only other commits in the repository are from you.