### PR TITLE
Make English the default language for the thesis

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -21,7 +21,9 @@
 \usepackage[latin9]{inputenc}
 
 %%% Language support
-\usepackage[english, dutch]{babel}
+%%% The last language in the option list (english) will be active.
+%%% See https://www.overleaf.com/learn/latex/International_language_support
+\usepackage[dutch, english]{babel}
 
 %%% Document elements
 \usepackage{acronym}


### PR DESCRIPTION
Currently Dutch is the default language for the thesis.
Various packages will use Dutch to generate strings such as "last accessed on" for references in Dutch.
That is the opposite of what we want.

See https://www.overleaf.com/learn/latex/International_language_support to see why the order matters.

@feitosa-daniel 